### PR TITLE
feat: 新增接口 获取帖子的Markdown原文

### DIFF
--- a/src/article.ts
+++ b/src/article.ts
@@ -304,6 +304,25 @@ export class Article {
     }
   }
 
+  /**
+   * 获取帖子的Markdown原文
+   * @param articleId 文章Id
+   */
+  async md(articleId: string): Promise<string> {
+    let rsp;
+    try {
+      rsp = await request({
+        url: `api/article/md/${articleId}?apiKey=${this.apiKey}`,
+      });
+
+      if (rsp.code) throw new Error(rsp.msg);
+
+      return rsp;
+    } catch (e) {
+      throw e;
+    }
+  }
+
   channel(id: string, type: ArticleType): ArticleChannel {
     if (!this.channels[id]) this.channels[id] = new ArticleChannel(this.apiKey, id, type);
     return this.channels[id];


### PR DESCRIPTION
[摸鱼派社区开放 API 使用文档 V2.1.8](https://fishpi.cn/article/1636516552191) 帖子部分 新增接口 获取帖子的Markdown原文